### PR TITLE
Fix email reply formatting

### DIFF
--- a/supabase/functions/send-email/index.ts
+++ b/supabase/functions/send-email/index.ts
@@ -56,6 +56,11 @@ const handler = async (req: Request): Promise<Response> => {
     const emailRequest: EmailRequest = await req.json();
     console.log('Sending email:', emailRequest);
 
+    // Replace newline sequences with <br> tags so plain text replies keep their
+    // formatting when delivered as HTML emails. The regex handles both Windows
+    // (\r\n) and Unix (\n) style newlines.
+    const formattedHtml = emailRequest.html.replace(/\r?\n/g, '<br>');
+
     const res = await fetch("https://api.resend.com/emails", {
       method: "POST",
       headers: {
@@ -66,7 +71,7 @@ const handler = async (req: Request): Promise<Response> => {
         from: emailRequest.from,
         to: emailRequest.to,
         subject: emailRequest.subject,
-        html: emailRequest.html,
+        html: formattedHtml,
       }),
     });
 

--- a/supabase/migrations/202507091901_update_pg_graphql.sql
+++ b/supabase/migrations/202507091901_update_pg_graphql.sql
@@ -1,0 +1,2 @@
+-- Upgrade pg_graphql extension to latest version
+ALTER EXTENSION IF EXISTS pg_graphql UPDATE;


### PR DESCRIPTION
## Summary
- handle Windows newline sequences in HTML email formatting
- add migration to update pg_graphql extension

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_686eb53bd324832884ed3a1c151c2da0